### PR TITLE
feat: add ability to use selector as Node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,9 @@ class Yace {
       throw new Error("selector is not defined");
     }
 
-    this.root = document.querySelector(selector);
+    this.root = selector instanceof Node
+      ? selector
+      : document.querySelector(selector);
 
     if (!this.root) {
       throw new Error(`element with "${selector}" selector is not exist`);

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,13 @@ test("constructor", (t) => {
   document.querySelector = () => document.createElement("div");
 });
 
+test("custom container", (t) => {
+  const container = document.createElement("div");
+  const editor = new Yace(container);
+
+  t.ok(editor instanceof Yace, "constructor should return editor instance");
+});
+
 test("instance", (t) => {
   const editor = new Yace("#editor", { value: "test" });
 


### PR DESCRIPTION
The issue I'm seeing here is that when setting up editor `selector` must be an argument of `querySelector`.

```js
const editor = new Yace("#editor", { ... });
```

I propose that it allows developer to use their own containers. This is useful for adding multiple dynamic editors to dom.


```js
const container = document.createElement('div';)
const editor = new Yace(container, { ... });
```
